### PR TITLE
remove initialize_towers() and add()

### DIFF
--- a/offline/packages/CaloBase/TowerInfoContainer.h
+++ b/offline/packages/CaloBase/TowerInfoContainer.h
@@ -31,11 +31,9 @@ class TowerInfoContainer : public PHObject
   typedef std::pair<Iterator, Iterator> Range;
 
   virtual void Reset() override {}
-  virtual void add(TowerInfo* /*ti*/, int /*pos*/) {}
   virtual TowerInfo* at(int /*pos*/) { return nullptr; }
   virtual unsigned int encode_key(unsigned int /*towerIndex*/) { return UINT_MAX; }
   virtual unsigned int decode_key(unsigned int /*towerIndex*/) { return UINT_MAX; }
-  virtual void initialize_towers(){}
 
   virtual size_t size() { return 0; }
 

--- a/offline/packages/CaloBase/TowerInfoContainer.h
+++ b/offline/packages/CaloBase/TowerInfoContainer.h
@@ -19,7 +19,8 @@ class TowerInfoContainer : public PHObject
   {
     EMCAL = 0,
     HCAL = 1,
-    SEPD = 2
+    SEPD = 2,
+    DETECTOR_INVALID = 9999
   };
 
   TowerInfoContainer() = default;

--- a/offline/packages/CaloBase/TowerInfoContainerv1.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.cc
@@ -55,6 +55,14 @@ TowerInfoContainerv1::TowerInfoContainerv1(DETECTOR detec)
 
   _clones->SetOwner();
   _clones->SetName("TowerInfoContainerv1");
+
+  for (int i=0; i<nchannels; ++i)
+  {
+    // as tower numbers are fixed per event
+    // construct towers once per run, and clear the towers for first use
+    _clones->ConstructedAt(i,"C");
+  }
+
 }
 
 TowerInfoContainerv1::~TowerInfoContainerv1()
@@ -64,40 +72,7 @@ TowerInfoContainerv1::~TowerInfoContainerv1()
 
 void TowerInfoContainerv1::Reset()
 {
-  _map.clear();
-  _towers.clear();
-  _clones->Clear();
-}
-
-void TowerInfoContainerv1::initialize_towers()
-{
-  
-  int nchannels = 744;
-  if (_detector == DETECTOR::SEPD)
-    {
-      nchannels= 744;
-    }
-  else if (_detector == DETECTOR::EMCAL)
-    {
-      nchannels= 24576;
-    }
-  else if (_detector == DETECTOR::HCAL)
-    {
-    nchannels= 1536;
-    }
-  TowerInfov1 *tower = new TowerInfov1();
-  tower->set_energy(0);
-  for (int i = 0 ; i < nchannels;i++)
-    {
-      new ((*_clones)[i]) TowerInfov1(*tower);
-    }
-  delete tower;
-}
-
-
-void TowerInfoContainerv1::add(TowerInfov1* ti, int pos)
-{
-  new ((*_clones)[pos]) TowerInfov1(*ti);
+  _clones->Clear("C");
 }
 
 TowerInfov1* TowerInfoContainerv1::at(int pos)

--- a/offline/packages/CaloBase/TowerInfoContainerv1.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.cc
@@ -73,11 +73,22 @@ void TowerInfoContainerv1::Reset()
 {
   // clear content of towers in the container for the next event
 
-  for (Int_t i = 0; i < _clones->GetSize(); ++i)
+  for (Int_t i = 0; i < _clones->GetEntriesFast(); ++i)
   {
     TObject* obj = _clones->UncheckedAt(i);
+
+    if (obj==nullptr)
+    {
+      std::cout<<__PRETTY_FUNCTION__<<" Fatal access error:"
+          <<" _clones->GetSize() = "<<_clones->GetSize()
+          <<" _clones->GetEntriesFast() = "<<_clones->GetEntriesFast()
+          <<" i = "<<i<<std::endl;
+      _clones->Print();
+    }
+
     assert(obj);
 
+    // same as TClonesArray::Clear() but only clear but not to erase all towers
     obj->Clear();
     obj->ResetBit(kHasUUID);
     obj->ResetBit(kIsReferenced);

--- a/offline/packages/CaloBase/TowerInfoContainerv1.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.cc
@@ -5,15 +5,15 @@
 
 #include <TClonesArray.h>
 
-  //---------------------------------------------------------------------------------------------------------------------------------
-  //  Critical Note to any user: The object as implemented MUST have sequential towers  
-  //  filled WITHOUT GAPS (though can be filled in an arbitrary order. The TClonesArray object 
-  // that is being used as the backbone does not play well with empty entries in between full ones.
-  //  Please see coresoftware/simulation/g4simulation/g4calo/RawTowerBuilder.cc for an example 
-  //  use case.  Namely it is key to call TowerInfoContainerv1::initialize_towers during your process event loop
-  //---------------------------------------------------------------------------------------------------------------------------------
+#include <cassert>
 
-
+//---------------------------------------------------------------------------------------------------------------------------------
+//  Critical Note to any user: The object as implemented MUST have sequential towers
+//  filled WITHOUT GAPS (though can be filled in an arbitrary order. The TClonesArray object
+// that is being used as the backbone does not play well with empty entries in between full ones.
+//  Please see coresoftware/simulation/g4simulation/g4calo/RawTowerBuilder.cc for an example
+//  use case.  Namely it is key to call TowerInfoContainerv1::initialize_towers during your process event loop
+//---------------------------------------------------------------------------------------------------------------------------------
 
 int emcadc[8][8] = {
     {62, 60, 46, 44, 30, 28, 14, 12},
@@ -41,28 +41,27 @@ TowerInfoContainerv1::TowerInfoContainerv1(DETECTOR detec)
   int nchannels = 744;
   if (_detector == DETECTOR::SEPD)
   {
-    nchannels= 744;
+    nchannels = 744;
   }
   else if (_detector == DETECTOR::EMCAL)
   {
-    nchannels= 24576;
+    nchannels = 24576;
   }
   else if (_detector == DETECTOR::HCAL)
   {
-    nchannels= 1536;
+    nchannels = 1536;
   }
   _clones = new TClonesArray("TowerInfov1", nchannels);
 
   _clones->SetOwner();
   _clones->SetName("TowerInfoContainerv1");
 
-  for (int i=0; i<nchannels; ++i)
+  for (int i = 0; i < nchannels; ++i)
   {
     // as tower numbers are fixed per event
     // construct towers once per run, and clear the towers for first use
-    _clones->ConstructedAt(i,"C");
+    _clones->ConstructedAt(i, "C");
   }
-
 }
 
 TowerInfoContainerv1::~TowerInfoContainerv1()
@@ -72,7 +71,18 @@ TowerInfoContainerv1::~TowerInfoContainerv1()
 
 void TowerInfoContainerv1::Reset()
 {
-  _clones->Clear("C");
+  // clear content of towers in the container for the next event
+
+  for (Int_t i = 0; i < _clones->GetSize(); ++i)
+  {
+    TObject* obj = _clones->UncheckedAt(i);
+    assert(obj);
+
+    obj->Clear();
+    obj->ResetBit(kHasUUID);
+    obj->ResetBit(kIsReferenced);
+    obj->SetUniqueID(0);
+  }
 }
 
 TowerInfov1* TowerInfoContainerv1::at(int pos)

--- a/offline/packages/CaloBase/TowerInfoContainerv1.h
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.h
@@ -13,18 +13,16 @@ class TowerInfoContainerv1 : public TowerInfoContainer
  public:
   TowerInfoContainerv1(DETECTOR detec = DETECTOR::EMCAL);
   ~TowerInfoContainerv1() override;
-   typedef std::map<unsigned int, TowerInfo *> Map;
-   typedef Map::iterator Iterator;
+  typedef std::map<unsigned int, TowerInfo *> Map;
+  typedef Map::iterator Iterator;
   typedef Map::const_iterator ConstIterator;
   typedef std::pair<ConstIterator, ConstIterator> ConstRange;
   typedef std::pair<Iterator, Iterator> Range;
 
   void Reset() override;
-  void add(TowerInfov1 *ti, int pos);
   TowerInfov1 *at(int pos) override;
   unsigned int encode_key(unsigned int towerIndex) override;
   unsigned int decode_key(unsigned int tower_key) override;
-  void initialize_towers() override;
   Range getTowers(void);
 
   size_t size() override { return _clones->GetEntries(); }
@@ -32,23 +30,14 @@ class TowerInfoContainerv1 : public TowerInfoContainer
   unsigned int getTowerPhiBin(unsigned int towerIndex) override;
   unsigned int getTowerEtaBin(unsigned int towerIndex) override;
 
-  ConstIter begin() const override { return _map.begin(); }
-  ConstIter find(int key) const override { return _map.find(key); }
-  ConstIter end() const override { return _map.end(); }
-
-  Iter begin() override { return _map.begin(); }
-  Iter find(int key) override { return _map.find(key); }
-  Iter end() override { return _map.end(); }
-
  protected:
   TClonesArray *_clones;
   DETECTOR _detector;
-  TowerMap _map;
-  Map _towers;
+
+  //! static Tower index map, not saved on DST output and constructed on the fly
+  Map _towers;  //!
 
  private:
-  using TowerInfoContainer::add;
-
   ClassDefOverride(TowerInfoContainerv1, 1);
 };
 

--- a/offline/packages/CaloBase/TowerInfoContainerv1.h
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.h
@@ -11,7 +11,11 @@
 class TowerInfoContainerv1 : public TowerInfoContainer
 {
  public:
-  TowerInfoContainerv1(DETECTOR detec = DETECTOR::EMCAL);
+  TowerInfoContainerv1(DETECTOR detec);
+
+  // default constructor for ROOT IO
+  TowerInfoContainerv1() {}
+
   ~TowerInfoContainerv1() override;
   typedef std::map<unsigned int, TowerInfo *> Map;
   typedef Map::iterator Iterator;
@@ -31,8 +35,8 @@ class TowerInfoContainerv1 : public TowerInfoContainer
   unsigned int getTowerEtaBin(unsigned int towerIndex) override;
 
  protected:
-  TClonesArray *_clones;
-  DETECTOR _detector;
+  TClonesArray *_clones = nullptr;
+  DETECTOR _detector = DETECTOR_INVALID;
 
   //! static Tower index map, not saved on DST output and constructed on the fly
   Map _towers;  //!

--- a/offline/packages/CaloBase/TowerInfov1.cc
+++ b/offline/packages/CaloBase/TowerInfov1.cc
@@ -11,3 +11,9 @@ void TowerInfov1::Reset()
   _time = 0;
   _energy = NAN;
 }
+
+void TowerInfov1::Clear(Option_t* )
+{
+  _time = 0;
+  _energy = 0;
+}

--- a/offline/packages/CaloBase/TowerInfov1.h
+++ b/offline/packages/CaloBase/TowerInfov1.h
@@ -15,6 +15,9 @@ class TowerInfov1 : public TowerInfo
   ~TowerInfov1() override {}
   void Reset() override;
 
+  //! Clear is used by TClonesArray to reset the tower to initial state without calling destructor/constructor
+  void Clear(Option_t* = "") override;
+
   void set_time(short t) override { _time = t; }
   short get_time() override { return _time; }
   void set_energy(float energy) override { _energy = energy; }

--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -131,12 +131,8 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
   int n_channels = processed_waveforms.size();
   for (int i = 0 ; i < n_channels;i++)
     {
-      TowerInfov1 *caloinfo = new TowerInfov1();
-      caloinfo->set_time(processed_waveforms.at(i).at(0));
-      caloinfo->set_energy(processed_waveforms.at(i).at(1));
-
-      m_CaloInfoContainer->add(caloinfo,i);
-      delete caloinfo;
+      m_CaloInfoContainer->at(i)->set_time(processed_waveforms.at(i).at(0));
+      m_CaloInfoContainer->at(i)->set_energy(processed_waveforms.at(i).at(1));
     }
   
   waveforms.clear();

--- a/offline/packages/CaloReco/CaloTowerCalib.cc
+++ b/offline/packages/CaloReco/CaloTowerCalib.cc
@@ -120,16 +120,11 @@ int CaloTowerCalib::process_event(PHCompositeNode * /*topNode*/)
       TowerInfo *caloinfo_raw = rtiter->second;
       float raw_amplitude = caloinfo_raw->get_energy();
 
-      TowerInfov1 *caloinfo_calib = new TowerInfov1(*caloinfo_raw);
-     
       float calibconst = cdbttree->GetFloatValue(key, m_fieldname);
 
-      caloinfo_calib->set_energy(raw_amplitude * calibconst);
-
       unsigned int channel = _calib_towers->decode_key(key);
-
-      _calib_towers->add(caloinfo_calib, channel);
       
+      _calib_towers->at(channel)->set_energy(raw_amplitude * calibconst);
     }
   
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/CaloReco/RawTowerCalibration.cc
+++ b/offline/packages/CaloReco/RawTowerCalibration.cc
@@ -239,7 +239,6 @@ int RawTowerCalibration::process_event(PHCompositeNode * /*topNode*/)
 
   if ( m_UseTowerInfo > 0)
     {
-      _calib_towerinfos->initialize_towers();  // initializes the TClones array for every tower in the detector system with 0 energy towers
       TowerInfoContainer::ConstRange begin_end = _raw_towerinfos->getTowers();
       TowerInfoContainer::ConstIterator rtiter;
       for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)

--- a/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
@@ -310,24 +310,6 @@ int HcalRawTowerBuilder::process_event(PHCompositeNode *topNode)
       exit(1);
     }
 
-
-    if (m_UseTowerInfo > 0)
-      {
-	// int nchannels = 1536; // number of channels for the HCals
-	// for (int i = 0; i < nchannels;i++) // this is implemented to ensure that every sequential element in the TClonesArray is populated with a 0 energy tower
-	//   {
-	//     TowerInfo  * towerinfo = m_TowerInfoContainer->at(i);
-	//     if (!towerinfo)
-	//       {
-	// 	towerinfo = new TowerInfo();
-	// 	towerinfo->set_energy(0);
-	// 	m_TowerInfoContainer->add(towerinfo,i); 
-	//       }
-	//   }
-	m_TowerInfoContainer->initialize_towers();
-      } 
-
-
   // get cells
   std::string cellnodename = "G4CELL_" + m_InputDetector;
   PHG4CellContainer *slats = findNode::getClass<PHG4CellContainer>(topNode, cellnodename);
@@ -411,19 +393,18 @@ int HcalRawTowerBuilder::process_event(PHCompositeNode *topNode)
 	
 	unsigned int towerkey = (etabin << 16U) + phibin;
 	unsigned int towerindex = m_TowerInfoContainer->decode_key(towerkey);
-	
-	towerinfo = m_TowerInfoContainer->at(towerindex);
-	if (!towerinfo)
-	  {
-	    towerinfo = new TowerInfo();
-	    towerinfo->set_energy(0);
-	    m_TowerInfoContainer->add(towerinfo,towerindex); //By way of the initializer this should never happen
-	  }
-	towerinfo->set_energy(towerinfo->get_energy() + cell_weight);
+
+        towerinfo = m_TowerInfoContainer->at(towerindex);
+        if (!towerinfo)
+        {
+          std::cout << __PRETTY_FUNCTION__ << ": missing towerkey = " << towerkey << " in m_TowerInfoContainer!";
+          exit(1);
+        }
+        else
+        {
+          towerinfo->set_energy(towerinfo->get_energy() + cell_weight);
+        }
       }
-
-
-
   }
 
   double towerE = 0;

--- a/simulation/g4simulation/g4calo/RawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/RawTowerBuilder.cc
@@ -121,10 +121,6 @@ int RawTowerBuilder::process_event(PHCompositeNode *topNode)
       exit(1);
     }
 
-    if (m_UseTowerInfo > 0)
-      {
-	m_TowerInfoContainer->initialize_towers();
-      } 
     // get cells
   std::string cellnodename = "G4CELL_" + m_Detector;
   PHG4CellContainer *cells = findNode::getClass<PHG4CellContainer>(topNode, cellnodename);
@@ -228,13 +224,15 @@ int RawTowerBuilder::process_event(PHCompositeNode *topNode)
 	unsigned int towerkey = (etabin << 16U) + phibin;
 	unsigned int towerindex = m_TowerInfoContainer->decode_key(towerkey);
 	towerinfo = m_TowerInfoContainer->at(towerindex);
-	if (!towerinfo)
-	  {
-	    towerinfo = new TowerInfo();
-	    towerinfo->set_energy(0);
-	    m_TowerInfoContainer->add(towerinfo,towerindex); //By way of the initializer this should never happen
-	  }
-	towerinfo->set_energy(towerinfo->get_energy() + cell_weight);
+        if (!towerinfo)
+        {
+          std::cout << __PRETTY_FUNCTION__ << ": missing towerkey = " << towerkey << " in m_TowerInfoContainer!";
+          exit(1);
+        }
+        else
+        {
+          towerinfo->set_energy(towerinfo->get_energy() + cell_weight);
+        }
       }
   }
 

--- a/simulation/g4simulation/g4calo/RawTowerDigitizer.cc
+++ b/simulation/g4simulation/g4calo/RawTowerDigitizer.cc
@@ -145,13 +145,6 @@ int RawTowerDigitizer::process_event(PHCompositeNode */**topNode*/)
   // pedestals
   RawTowerGeomContainer::ConstRange all_towers = m_RawTowerGeom->get_tower_geometries();
 
-
-  if (m_UseTowerInfo > 0)
-    {
-      m_RawTowerInfos->initialize_towers();
-    } 
-  
-
   double deadChanEnergy = 0;
 
   for (RawTowerGeomContainer::ConstIterator it = all_towers.first;


### PR DESCRIPTION
Introducing changes to https://github.com/sPHENIX-Collaboration/coresoftware/pull/1801 :
1, the size of `TowerInfoContainerv1` is static. In this case, ROOT `TClonesArray` prefer not to call destructor and constructor constantly, but use `ConstructedAt()` and `Clear()` instead. See https://root.cern/doc/master/classTClonesArray.html 3rd sample and NOTE 2
2. `TowerInfoContainerv1::add()` does call copy constructor, which can be simply replaced with `TowerInfoContainerv1::at()->set_energy()` etc. Otherwise, all the instances `TowerInfoContainerv1::add()` are called are very inefficient, with new and delete leading to expensive memory allocation ops which defeat the very purpose of `TClonesArray`
3. `TowerInfoContainerv1::_map` is doing nothing and only causing confusion to users. Remove until we find a purpose for it. 
4. `TowerInfoContainerv1::_towers` is static object. Constructing only once and NOT to saved to DST. 

I did not test these changes other than compilation. Good to verify functionality. 

Unrelated: 
Please split TowerInfoContainerv1::encode_key(unsigned int towerIndex) into three functions, one for each detector, and called from TowerInfoContainerv1::encode_key() with a switch. The current long function is prone to editing conflict from three subsystems. They are likely best be made an encoder/decoder class that can pair encoder decoder together for each subsystem. 